### PR TITLE
[Wave 1-A] Pipeline Reliability

### DIFF
--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/Excite.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/Excite.groovy
@@ -4,6 +4,9 @@ import com.parisesoftware.excite.core.api.IExciteFacade
 import com.parisesoftware.excite.core.api.IOutputCommand
 import com.parisesoftware.excite.core.api.ITransformationAlgorithm
 import com.parisesoftware.excite.core.api.IValidationAlgorithm
+import com.parisesoftware.excite.core.api.executor.IMarkupTransformer
+import com.parisesoftware.excite.core.api.resolver.IFileParser
+import com.parisesoftware.excite.core.api.resolver.IFileSystemService
 import com.parisesoftware.excite.core.internal.ExciteFacadeImpl
 
 /**
@@ -26,6 +29,10 @@ class Excite {
      */
     static void run(final String aDirectory, final ITransformationAlgorithm aTransformationAlgorithm,
                     final IValidationAlgorithm aValidationAlgorithm, final IOutputCommand anOutputCommand) {
+        if (aDirectory == null) throw new IllegalArgumentException('aDirectory must not be null')
+        if (aTransformationAlgorithm == null) throw new IllegalArgumentException('aTransformationAlgorithm must not be null')
+        if (aValidationAlgorithm == null) throw new IllegalArgumentException('aValidationAlgorithm must not be null')
+        if (anOutputCommand == null) throw new IllegalArgumentException('anOutputCommand must not be null')
         facade().run(aDirectory, aTransformationAlgorithm, aValidationAlgorithm, anOutputCommand)
     }
 
@@ -34,6 +41,13 @@ class Excite {
      */
     private static IExciteFacade facade() {
         return new ExciteFacadeImpl()
+    }
+
+    @groovy.transform.PackageScope
+    static IExciteFacade facadeWith(IMarkupTransformer markupTransformer,
+                                     IFileSystemService fileSystemService,
+                                     IFileParser fileParser) {
+        return new ExciteFacadeImpl(markupTransformer, fileSystemService, fileParser)
     }
 
 }

--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/api/resolver/IFileSystemService.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/api/resolver/IFileSystemService.groovy
@@ -22,4 +22,8 @@ interface IFileSystemService {
      */
     List<File> getFilesInDirectory(final String aFilePath, final Predicate<File> isApplicableFile)
 
+    default List<File> getFilesInDirectory(final String aFilePath) {
+        return getFilesInDirectory(aFilePath, com.parisesoftware.excite.core.internal.parser.FilePredicate.isXmlFile)
+    }
+
 }

--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/ExciteFacadeImpl.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/ExciteFacadeImpl.groovy
@@ -9,6 +9,7 @@ import com.parisesoftware.excite.core.api.IValidationAlgorithm
 import com.parisesoftware.excite.core.internal.parser.FileParser
 import com.parisesoftware.excite.core.internal.parser.FilePredicate
 import com.parisesoftware.excite.core.internal.parser.FileSystemService
+import com.parisesoftware.excite.core.api.ExciteException
 import com.parisesoftware.excite.core.api.executor.IMarkupTransformer
 import com.parisesoftware.excite.core.internal.transformer.MarkupTransformer
 import groovy.xml.slurpersupport.GPathResult
@@ -40,6 +41,12 @@ class ExciteFacadeImpl implements IExciteFacade {
         this.fileParser = new FileParser()
     }
 
+    ExciteFacadeImpl(IMarkupTransformer markupTransformer, IFileSystemService fileSystemService, IFileParser fileParser) {
+        this.markupTransformer = markupTransformer
+        this.fileSystemService = fileSystemService
+        this.fileParser = fileParser
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -47,13 +54,22 @@ class ExciteFacadeImpl implements IExciteFacade {
              final ITransformationAlgorithm aTransformationAlgorithm,
              final IValidationAlgorithm aValidationAlgorithm,
              final IOutputCommand anOutputCommand) {
+        if (aDirectory == null) throw new IllegalArgumentException('aDirectory must not be null')
+        if (aTransformationAlgorithm == null) throw new IllegalArgumentException('aTransformationAlgorithm must not be null')
+        if (aValidationAlgorithm == null) throw new IllegalArgumentException('aValidationAlgorithm must not be null')
+        if (anOutputCommand == null) throw new IllegalArgumentException('anOutputCommand must not be null')
         List<File> filesInDirectory = this.fileSystemService.getFilesInDirectory(aDirectory, GET_ONLY_XML_FILES)
         filesInDirectory.each { File curFile ->
-            GPathResult fileContents = this.fileParser.parseFile(curFile)
-
-            if (aValidationAlgorithm.validate(fileContents)) {
-                String transformedContent = this.markupTransformer.transform(fileContents, aTransformationAlgorithm)
-                anOutputCommand.execute(curFile, transformedContent)
+            try {
+                GPathResult fileContents = this.fileParser.parseFile(curFile)
+                if (aValidationAlgorithm.validate(fileContents)) {
+                    String transformedContent = this.markupTransformer.transform(fileContents, aTransformationAlgorithm)
+                    anOutputCommand.execute(curFile, transformedContent)
+                }
+            } catch (ExciteException e) {
+                throw e
+            } catch (Exception e) {
+                throw new ExciteException("Failed to process file: ${curFile.absolutePath}", e)
             }
         }
     }

--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/parser/FileParser.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/parser/FileParser.groovy
@@ -1,5 +1,6 @@
 package com.parisesoftware.excite.core.internal.parser
 
+import com.parisesoftware.excite.core.api.ExciteException
 import com.parisesoftware.excite.core.api.resolver.IFileParser
 import groovy.xml.XmlSlurper
 import groovy.xml.slurpersupport.GPathResult
@@ -20,8 +21,12 @@ class FileParser implements IFileParser {
      */
     @Override
     GPathResult parseFile(File aFile) {
-        final String fileText = aFile.text
-        return new XmlSlurper().parseText(fileText)
+        try {
+            final String fileText = aFile.getText('UTF-8')
+            return new XmlSlurper().parseText(fileText)
+        } catch (Exception e) {
+            throw new ExciteException("Failed to parse XML file: ${aFile.absolutePath}", e)
+        }
     }
 
 }

--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/parser/FileSystemService.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/parser/FileSystemService.groovy
@@ -1,5 +1,6 @@
 package com.parisesoftware.excite.core.internal.parser
 
+import com.parisesoftware.excite.core.api.ExciteException
 import com.parisesoftware.excite.core.api.resolver.IFileSystemService
 import groovy.io.FileType
 
@@ -23,6 +24,9 @@ class FileSystemService implements IFileSystemService {
         List<File> filesInDirectory = []
 
         File parentDirectory = new File(aFilePath)
+        if (!parentDirectory.exists() || !parentDirectory.isDirectory()) {
+            throw new ExciteException("Directory does not exist or is not readable: ${aFilePath}")
+        }
         parentDirectory.eachFileRecurse(FileType.FILES) { final File curFile ->
             if (isApplicableFile.test(curFile)) {
                 filesInDirectory << curFile


### PR DESCRIPTION
## Summary
- Null-checks on all 4 parameters in `Excite.run()` and `ExciteFacadeImpl.run()`
- `FileSystemService` validates the directory exists before scanning
- `FileParser` uses explicit UTF-8 encoding and wraps parse failures in `ExciteException` with filename context
- `ExciteFacadeImpl` wraps per-file processing in try-catch with file path context
- DI constructor added to `ExciteFacadeImpl`; `Excite.facadeWith()` factory method added for test injection
- `IFileSystemService` default no-predicate overload added