### PR TITLE
[Wave 1-B] Transform & Output Reliability

### DIFF
--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/output/OverwriteFileOutputCommand.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/output/OverwriteFileOutputCommand.groovy
@@ -1,6 +1,8 @@
 package com.parisesoftware.excite.core.internal.output
 
 import com.parisesoftware.excite.core.api.IOutputCommand
+import com.parisesoftware.excite.core.api.ExciteException
+import java.io.IOException
 
 /**
  * {@inheritDoc}
@@ -17,8 +19,13 @@ class OverwriteFileOutputCommand implements IOutputCommand {
      * @since 1.0.1
      */
     void execute(File initialFile, String transformedContent) {
-        initialFile.newWriter().withWriter { writer ->
-            writer << transformedContent
+        File tempFile = File.createTempFile('excite-', '.tmp', initialFile.parentFile)
+        try {
+            tempFile.setText(transformedContent, 'UTF-8')
+            tempFile.renameTo(initialFile)
+        } catch (IOException e) {
+            tempFile.delete()
+            throw new ExciteException("Failed to write file: ${initialFile.absolutePath}", e)
         }
     }
 

--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/transformer/MarkupTransformer.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/transformer/MarkupTransformer.groovy
@@ -3,7 +3,6 @@ package com.parisesoftware.excite.core.internal.transformer
 import com.parisesoftware.excite.core.api.ITransformationAlgorithm
 import com.parisesoftware.excite.core.api.executor.IMarkupTransformer
 import groovy.xml.slurpersupport.GPathResult
-import groovy.xml.StreamingMarkupBuilder
 import groovy.xml.XmlUtil
 
 /**
@@ -16,22 +15,12 @@ import groovy.xml.XmlUtil
  */
 class MarkupTransformer implements IMarkupTransformer {
 
-    private static final String UTF_8_ENCODING = 'UTF-8'
-
     /**
      * {@inheritDoc}
      */
     @Override
     String transform(GPathResult theInputComponent, ITransformationAlgorithm aTransformationAlgorithm) {
-        StreamingMarkupBuilder builder = new StreamingMarkupBuilder()
-        builder.encoding = UTF_8_ENCODING
-
         aTransformationAlgorithm.execute(theInputComponent)
-
-        def xml = builder.bind {
-            it.mkp.yieldUnescaped XmlUtil.serialize(theInputComponent)
-        }
-
-        return xml.toString()
+        return XmlUtil.serialize(theInputComponent)
     }
 }

--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/transformer/operation/GPathResultTransformer.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/transformer/operation/GPathResultTransformer.groovy
@@ -15,7 +15,11 @@ class GPathResultTransformer {
 
     @PackageScope
     static GPathResult findAllChildrenWithName(GPathResult aComponent, final String aName) {
-        return aComponent.children().findAll { GPathResult curChild -> curChild.name() == aName }
+        def result = aComponent.children().findAll { GPathResult curChild -> curChild.name() == aName }
+        if (!result) {
+            System.err.println("[EXCITE WARN] No child nodes found with name '${aName}'")
+        }
+        return result
     }
 
     /**

--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/validation/ChildNodeHasValueValidation.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/validation/ChildNodeHasValueValidation.groovy
@@ -30,7 +30,9 @@ class ChildNodeHasValueValidation implements IValidationAlgorithm {
      * @since 1.0.1
      */
     boolean validate(GPathResult node) {
-        return node[this.childNodeName] == this.childNodeValue
+        if (node == null) return false
+        def childValue = node[this.childNodeName]
+        return childValue != null && childValue.text() == this.childNodeValue
     }
 
 }


### PR DESCRIPTION
## Summary
- `MarkupTransformer` double-serialization fixed — now returns `XmlUtil.serialize()` directly
- `OverwriteFileOutputCommand` uses atomic temp-file-then-rename write strategy with `ExciteException` on failure
- `ChildNodeHasValueValidation` guards null input and uses `.text()` for correct GPathResult comparison
- `GPathResultTransformer` warns to stderr when no child nodes match the target name