### PR TITLE
[Wave 1-C] Build & Infrastructure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/pom.xml
+++ b/pom.xml
@@ -52,13 +52,11 @@
     </distributionManagement>
 
     <properties>
-        <revision>1.0.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
         <junit.version>4.13.2</junit.version>
-        <apache.commons-lang3.version>3.14.0</apache.commons-lang3.version>
         <spock.version>2.4-groovy-5.0</spock.version>
         <groovy.version>5.0.3</groovy.version>
         <cglib.version>3.3.0</cglib.version>
@@ -230,12 +228,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>${apache.commons-lang3.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
             <version>${groovy.version}</version>
@@ -272,6 +264,19 @@
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
             <version>${objenesis.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.13</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.13</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- Removed unused `commons-lang3` dependency and its version property
- Removed stale `<revision>1.0.0-SNAPSHOT</revision>` property (never referenced, conflicted with actual version)
- Added `slf4j-api:2.0.13` (compile) and `slf4j-simple:2.0.13` (test) dependencies for Wave 2 logging
- Added `.github/dependabot.yml` for weekly Maven dependency updates