### PR TITLE
[Wave 1-D] API Surface & CLI

### DIFF
--- a/excite-commandline/src/main/groovy/com/parisesoftware/excite/commandline/ExciteCLIRunner.groovy
+++ b/excite-commandline/src/main/groovy/com/parisesoftware/excite/commandline/ExciteCLIRunner.groovy
@@ -4,6 +4,7 @@ import com.parisesoftware.excite.core.Excite
 import com.parisesoftware.excite.core.api.IOutputCommand
 import com.parisesoftware.excite.core.api.ITransformationAlgorithm
 import com.parisesoftware.excite.core.api.IValidationAlgorithm
+import com.parisesoftware.excite.core.internal.output.ConsoleOutputCommand
 import com.parisesoftware.excite.core.internal.output.OverwriteFileOutputCommand
 import com.parisesoftware.excite.core.internal.transformer.RenameChildNodeTransformation
 import com.parisesoftware.excite.core.internal.validation.ChildNodeHasValueValidation
@@ -17,16 +18,23 @@ import com.parisesoftware.excite.core.internal.validation.ChildNodeHasValueValid
 class ExciteCLIRunner {
 
     static void main(String[] args) {
+        if (args.length < 1) {
+            println 'Usage: ExciteCLIRunner <directory> [console|file]'
+            return
+        }
+
+        final String parentDirectory = args[0]
+        final boolean writeToFile = args.length > 1 && args[1] == 'file'
+
+        final IOutputCommand encapsulatedOutputCommand = writeToFile
+            ? new OverwriteFileOutputCommand()
+            : new ConsoleOutputCommand()
 
         final ITransformationAlgorithm encapsulatedTransformation =
-                new RenameChildNodeTransformation('description', 'description_html')
+            new RenameChildNodeTransformation('description', 'description_html')
 
         final IValidationAlgorithm encapsulatedValidation =
-                new ChildNodeHasValueValidation('content-type', '/component/person')
-
-        final IOutputCommand encapsulatedOutputCommand = new OverwriteFileOutputCommand()
-
-        final String parentDirectory = '/Users/aparise/Projects/craftercms/crafter-authoring/data/repos/sites/pennmutualcom/sandbox/site/'
+            new ChildNodeHasValueValidation('content-type', '/component/person')
 
         Excite.run(parentDirectory, encapsulatedTransformation, encapsulatedValidation, encapsulatedOutputCommand)
     }

--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/parser/FilePredicate.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/parser/FilePredicate.groovy
@@ -15,7 +15,7 @@ class FilePredicate {
     private static final String XML_FILE_EXTENSION = '.xml'
 
     static final Predicate<File> isXmlFile = { File aFile ->
-        aFile.name.endsWith(XML_FILE_EXTENSION)
+        aFile.name.toLowerCase().endsWith(XML_FILE_EXTENSION)
     }
 
 }


### PR DESCRIPTION
## Summary
- `FilePredicate.isXmlFile` now uses case-insensitive extension matching (`.XML`, `.Xml`, etc.)
- `ExciteCLIRunner` rewritten to accept CLI arguments: `<directory> [console|file]`; hardcoded path removed