### PR TITLE
[Wave 2-E] Logging

### DIFF
--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/ExciteFacadeImpl.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/ExciteFacadeImpl.groovy
@@ -13,6 +13,8 @@ import com.parisesoftware.excite.core.api.ExciteException
 import com.parisesoftware.excite.core.api.executor.IMarkupTransformer
 import com.parisesoftware.excite.core.internal.transformer.MarkupTransformer
 import groovy.xml.slurpersupport.GPathResult
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 import java.util.function.Predicate
 
@@ -26,6 +28,8 @@ import java.util.function.Predicate
  * @since 1.0.0
  */
 class ExciteFacadeImpl implements IExciteFacade {
+
+    private static final Logger log = LoggerFactory.getLogger(ExciteFacadeImpl)
 
     private static final Predicate<File> GET_ONLY_XML_FILES = FilePredicate.isXmlFile
 
@@ -58,8 +62,10 @@ class ExciteFacadeImpl implements IExciteFacade {
         if (aTransformationAlgorithm == null) throw new IllegalArgumentException('aTransformationAlgorithm must not be null')
         if (aValidationAlgorithm == null) throw new IllegalArgumentException('aValidationAlgorithm must not be null')
         if (anOutputCommand == null) throw new IllegalArgumentException('anOutputCommand must not be null')
+        log.debug('Running Excite against directory: {}', aDirectory)
         List<File> filesInDirectory = this.fileSystemService.getFilesInDirectory(aDirectory, GET_ONLY_XML_FILES)
         filesInDirectory.each { File curFile ->
+            log.info('Processing: {}', curFile.name)
             try {
                 GPathResult fileContents = this.fileParser.parseFile(curFile)
                 if (aValidationAlgorithm.validate(fileContents)) {
@@ -69,8 +75,10 @@ class ExciteFacadeImpl implements IExciteFacade {
             } catch (ExciteException e) {
                 throw e
             } catch (Exception e) {
+                log.error('Failed to process file: {}', curFile.absolutePath, e)
                 throw new ExciteException("Failed to process file: ${curFile.absolutePath}", e)
             }
         }
+        log.info('Processed {} file(s) in: {}', filesInDirectory.size(), aDirectory)
     }
 }

--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/output/OverwriteFileOutputCommand.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/output/OverwriteFileOutputCommand.groovy
@@ -2,6 +2,8 @@ package com.parisesoftware.excite.core.internal.output
 
 import com.parisesoftware.excite.core.api.IOutputCommand
 import com.parisesoftware.excite.core.api.ExciteException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.io.IOException
 
 /**
@@ -13,18 +15,22 @@ import java.io.IOException
  */
 class OverwriteFileOutputCommand implements IOutputCommand {
 
+    private static final Logger log = LoggerFactory.getLogger(OverwriteFileOutputCommand)
+
     /**
      * {@inheritDoc}
      * @version 1.0.1
      * @since 1.0.1
      */
     void execute(File initialFile, String transformedContent) {
+        log.debug('Writing output to: {}', initialFile.absolutePath)
         File tempFile = File.createTempFile('excite-', '.tmp', initialFile.parentFile)
         try {
             tempFile.setText(transformedContent, 'UTF-8')
             tempFile.renameTo(initialFile)
         } catch (IOException e) {
             tempFile.delete()
+            log.error('Failed to write file: {}', initialFile.absolutePath, e)
             throw new ExciteException("Failed to write file: ${initialFile.absolutePath}", e)
         }
     }

--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/parser/FileParser.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/parser/FileParser.groovy
@@ -4,6 +4,8 @@ import com.parisesoftware.excite.core.api.ExciteException
 import com.parisesoftware.excite.core.api.resolver.IFileParser
 import groovy.xml.XmlSlurper
 import groovy.xml.slurpersupport.GPathResult
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /**
  * {@inheritDoc}
@@ -16,15 +18,19 @@ import groovy.xml.slurpersupport.GPathResult
  */
 class FileParser implements IFileParser {
 
+    private static final Logger log = LoggerFactory.getLogger(FileParser)
+
     /**
      * {@inheritDoc}
      */
     @Override
     GPathResult parseFile(File aFile) {
+        log.debug('Parsing file: {}', aFile.name)
         try {
             final String fileText = aFile.getText('UTF-8')
             return new XmlSlurper().parseText(fileText)
         } catch (Exception e) {
+            log.error('Failed to parse XML file: {}', aFile.absolutePath, e)
             throw new ExciteException("Failed to parse XML file: ${aFile.absolutePath}", e)
         }
     }

--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/parser/FileSystemService.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/parser/FileSystemService.groovy
@@ -3,6 +3,8 @@ package com.parisesoftware.excite.core.internal.parser
 import com.parisesoftware.excite.core.api.ExciteException
 import com.parisesoftware.excite.core.api.resolver.IFileSystemService
 import groovy.io.FileType
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 import java.util.function.Predicate
 
@@ -16,15 +18,19 @@ import java.util.function.Predicate
  */
 class FileSystemService implements IFileSystemService {
 
+    private static final Logger log = LoggerFactory.getLogger(FileSystemService)
+
     /**
      * {@inheritDoc}
      */
     @Override
     List<File> getFilesInDirectory(final String aFilePath, final Predicate<File> isApplicableFile = FilePredicate.isXmlFile) {
+        log.debug('Scanning directory: {}', aFilePath)
         List<File> filesInDirectory = []
 
         File parentDirectory = new File(aFilePath)
         if (!parentDirectory.exists() || !parentDirectory.isDirectory()) {
+            log.error('Directory does not exist or is not readable: {}', aFilePath)
             throw new ExciteException("Directory does not exist or is not readable: ${aFilePath}")
         }
         parentDirectory.eachFileRecurse(FileType.FILES) { final File curFile ->
@@ -33,6 +39,7 @@ class FileSystemService implements IFileSystemService {
             }
         }
 
+        log.info('Found {} XML file(s) in: {}', filesInDirectory.size(), aFilePath)
         return filesInDirectory
     }
 

--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/transformer/MarkupTransformer.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/transformer/MarkupTransformer.groovy
@@ -4,6 +4,8 @@ import com.parisesoftware.excite.core.api.ITransformationAlgorithm
 import com.parisesoftware.excite.core.api.executor.IMarkupTransformer
 import groovy.xml.slurpersupport.GPathResult
 import groovy.xml.XmlUtil
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /**
  * {@inheritDoc}
@@ -15,11 +17,14 @@ import groovy.xml.XmlUtil
  */
 class MarkupTransformer implements IMarkupTransformer {
 
+    private static final Logger log = LoggerFactory.getLogger(MarkupTransformer)
+
     /**
      * {@inheritDoc}
      */
     @Override
     String transform(GPathResult theInputComponent, ITransformationAlgorithm aTransformationAlgorithm) {
+        log.debug('Transforming markup')
         aTransformationAlgorithm.execute(theInputComponent)
         return XmlUtil.serialize(theInputComponent)
     }

--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/transformer/operation/GPathResultTransformer.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/transformer/operation/GPathResultTransformer.groovy
@@ -2,6 +2,8 @@ package com.parisesoftware.excite.core.internal.transformer.operation
 
 import groovy.transform.PackageScope
 import groovy.xml.slurpersupport.GPathResult
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /**
  * GPathResult Transformer
@@ -13,11 +15,13 @@ import groovy.xml.slurpersupport.GPathResult
  */
 class GPathResultTransformer {
 
+    private static final Logger log = LoggerFactory.getLogger(GPathResultTransformer)
+
     @PackageScope
     static GPathResult findAllChildrenWithName(GPathResult aComponent, final String aName) {
         def result = aComponent.children().findAll { GPathResult curChild -> curChild.name() == aName }
         if (!result) {
-            System.err.println("[EXCITE WARN] No child nodes found with name '${aName}'")
+            log.warn("No child nodes found with name '{}'", aName)
         }
         return result
     }


### PR DESCRIPTION
Add SLF4J DEBUG/INFO/WARN/ERROR logging to ExciteFacadeImpl, FileSystemService, FileParser, MarkupTransformer, OverwriteFileOutputCommand, and GPathResultTransformer. Replaces the System.err.println warning added in Wave 1.