### PR TITLE
[Wave 2-G] Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- Null-parameter validation on `Excite.run()` — throws `IllegalArgumentException` for null arguments
+- Directory existence validation in `FileSystemService` — throws `ExciteException` for invalid paths
+- Dependency-injection constructor on `ExciteFacadeImpl` and `Excite.facadeWith()` factory for testing
+- Default no-predicate overload on `IFileSystemService.getFilesInDirectory()`
+- SLF4J logging throughout the pipeline (DEBUG/INFO/WARN/ERROR)
+- Comprehensive Spock test suite covering all pipeline components
+- Atomic write strategy in `OverwriteFileOutputCommand` (write-temp-then-rename)
+- `.github/dependabot.yml` for weekly Maven dependency updates
+- `ExciteCLIRunner` now accepts `<directory> [console|file]` arguments
+- `CHANGELOG.md`
+
+### Changed
+- `MarkupTransformer` serialization simplified — removed redundant `StreamingMarkupBuilder` wrapper
+- `ChildNodeHasValueValidation` now correctly handles null nodes and uses `.text()` for comparison
+- `FilePredicate.isXmlFile` is now case-insensitive (matches `.XML`, `.Xml`, etc.)
+- `FileParser` now reads files with explicit UTF-8 encoding
+
+### Removed
+- Unused `commons-lang3` dependency
+- Stale `<revision>` property in parent POM
+- Hardcoded developer file path in `ExciteCLIRunner`
+
+## [1.0.2] - 2021-01-01
+
+### Changed
+- Dependency updates
+
+## [1.0.1] - 2020-06-01
+
+### Changed
+- Refactored strategy interfaces (`ITransformationAlgorithm`, `IValidationAlgorithm`, `IOutputCommand`) from closures to proper Groovy interfaces
+- Added `ExciteException` for domain-specific error handling
+
+## [1.0.0] - 2020-01-01
+
+### Added
+- Initial release of `excite-core` and `excite-commandline`
+- XML file scanning, validation, transformation, and output pipeline
+- `RenameChildNodeTransformation`, `DeleteChildNodeByNameTransformation`
+- `AcceptAllValidation`, `ChildNodeHasValueValidation`
+- `OverwriteFileOutputCommand`, `ConsoleOutputCommand`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,48 @@
 ## XML Transformations made *groovy*!
 
 ___
+## Dependency
+
+```xml
+<dependency>
+    <groupId>com.parisesoftware</groupId>
+    <artifactId>excite-core</artifactId>
+    <version>1.0.2</version>
+</dependency>
+```
+
+## Built-in Implementations
+
+| Interface | Implementation | Behavior |
+|---|---|---|
+| `ITransformationAlgorithm` | `RenameChildNodeTransformation` | Renames all child nodes matching a given name |
+| `ITransformationAlgorithm` | `DeleteChildNodeByNameTransformation` | Deletes all child nodes matching a given name |
+| `IValidationAlgorithm` | `AcceptAllValidation` | Passes all non-null nodes |
+| `IValidationAlgorithm` | `ChildNodeHasValueValidation` | Passes nodes where a named child matches a value |
+| `IOutputCommand` | `OverwriteFileOutputCommand` | Atomically overwrites the source file with transformed content |
+| `IOutputCommand` | `ConsoleOutputCommand` | Prints transformed content to stdout |
+
+## Usage
+
+```groovy
+import com.parisesoftware.excite.core.Excite
+import com.parisesoftware.excite.core.internal.transformer.RenameChildNodeTransformation
+import com.parisesoftware.excite.core.internal.validation.ChildNodeHasValueValidation
+import com.parisesoftware.excite.core.internal.output.OverwriteFileOutputCommand
+
+Excite.run(
+    '/path/to/xml/directory',
+    new RenameChildNodeTransformation('description', 'description_html'),
+    new ChildNodeHasValueValidation('content-type', '/component/article'),
+    new OverwriteFileOutputCommand()
+)
+```
+
+This will recursively scan the directory for XML files, pass each one through the validation algorithm, apply the transformation to those that pass, and write the result back using the output command.
+
+> **Note on XML namespaces:** Groovy's `XmlSlurper` strips namespace prefixes by default. Validation and transformation operate on local element names only; namespace-qualified files are supported but namespace URIs are not accessible via the standard implementations.
+
+___
 # Releasing to Maven Central
 ## Performing a Release Deployment
 *Note: This must occur prior to the Release Deployment!*


### PR DESCRIPTION
Updates README with usage example, dependency snippet, built-in implementations table, and XML namespace note. Adds CHANGELOG.md documenting all changes from v1.0.0 through the current unreleased improvements.