### PR TITLE
[Wave 2-F] Test Suite

### DIFF
--- a/excite-core/src/test/groovy/com/parisesoftware/excite/core/ExciteIntegrationTest.groovy
+++ b/excite-core/src/test/groovy/com/parisesoftware/excite/core/ExciteIntegrationTest.groovy
@@ -1,0 +1,44 @@
+package com.parisesoftware.excite.core
+
+import com.parisesoftware.excite.core.internal.output.ConsoleOutputCommand
+import com.parisesoftware.excite.core.internal.transformer.DeleteChildNodeByNameTransformation
+import com.parisesoftware.excite.core.internal.validation.ChildNodeHasValueValidation
+import spock.lang.Specification
+
+class ExciteIntegrationTest extends Specification {
+
+    File tempDir
+    PrintStream originalOut
+    ByteArrayOutputStream capturedOut
+
+    def "run processes matching XML file and deletes type node, skipping non-matching file"() {
+        given:
+        tempDir = File.createTempDir()
+        new File(tempDir, 'match.xml').setText('<root><type>target</type></root>', 'UTF-8')
+        new File(tempDir, 'nomatch.xml').setText('<root><type>other</type></root>', 'UTF-8')
+
+        originalOut = System.out
+        capturedOut = new ByteArrayOutputStream()
+        System.setOut(new PrintStream(capturedOut))
+
+        when:
+        Excite.run(
+            tempDir.absolutePath,
+            new DeleteChildNodeByNameTransformation('type'),
+            new ChildNodeHasValueValidation('type', 'target'),
+            new ConsoleOutputCommand()
+        )
+
+        then:
+        String output = capturedOut.toString()
+        output.contains('<?xml')
+        !output.contains('<type>')
+        !output.contains('target')
+        noExceptionThrown()
+
+        cleanup:
+        System.setOut(originalOut)
+        tempDir?.deleteDir()
+    }
+
+}

--- a/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/output/ConsoleOutputCommandTest.groovy
+++ b/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/output/ConsoleOutputCommandTest.groovy
@@ -1,0 +1,31 @@
+package com.parisesoftware.excite.core.internal.output
+
+import spock.lang.Specification
+
+class ConsoleOutputCommandTest extends Specification {
+
+    PrintStream originalOut
+    ByteArrayOutputStream capturedOut
+
+    def setup() {
+        originalOut = System.out
+        capturedOut = new ByteArrayOutputStream()
+        System.setOut(new PrintStream(capturedOut))
+    }
+
+    def "execute prints transformed content to System.out"() {
+        given:
+        File someFile = new File('irrelevant.xml')
+
+        when:
+        new ConsoleOutputCommand().execute(someFile, 'content')
+
+        then:
+        capturedOut.toString().contains('content')
+    }
+
+    def cleanup() {
+        System.setOut(originalOut)
+    }
+
+}

--- a/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/output/OverwriteFileOutputCommandTest.groovy
+++ b/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/output/OverwriteFileOutputCommandTest.groovy
@@ -1,0 +1,36 @@
+package com.parisesoftware.excite.core.internal.output
+
+import com.parisesoftware.excite.core.api.ExciteException
+import spock.lang.Specification
+
+class OverwriteFileOutputCommandTest extends Specification {
+
+    File tempFile
+
+    def "execute overwrites temp file with provided content"() {
+        given:
+        tempFile = File.createTempFile('excite-output-', '.xml')
+
+        when:
+        new OverwriteFileOutputCommand().execute(tempFile, '<root/>')
+
+        then:
+        tempFile.getText('UTF-8') == '<root/>'
+    }
+
+    def "execute throws an exception when writing to file in non-existent directory"() {
+        given:
+        File badFile = new File('/this/path/does/not/exist/output.xml')
+
+        when:
+        new OverwriteFileOutputCommand().execute(badFile, '<root/>')
+
+        then:
+        thrown(Exception)
+    }
+
+    def cleanup() {
+        tempFile?.delete()
+    }
+
+}

--- a/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/parser/FileParserTest.groovy
+++ b/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/parser/FileParserTest.groovy
@@ -1,0 +1,41 @@
+package com.parisesoftware.excite.core.internal.parser
+
+import com.parisesoftware.excite.core.api.ExciteException
+import groovy.xml.slurpersupport.GPathResult
+import spock.lang.Specification
+
+class FileParserTest extends Specification {
+
+    File validTempFile
+    File invalidTempFile
+
+    def "parseFile returns correct GPathResult for valid XML"() {
+        given:
+        validTempFile = File.createTempFile('excite-test-', '.xml')
+        validTempFile.setText('<myroot><child>hello</child></myroot>', 'UTF-8')
+
+        when:
+        GPathResult result = new FileParser().parseFile(validTempFile)
+
+        then:
+        result.name() == 'myroot'
+    }
+
+    def "parseFile throws ExciteException for invalid XML content"() {
+        given:
+        invalidTempFile = File.createTempFile('excite-test-bad-', '.xml')
+        invalidTempFile.setText('not xml content', 'UTF-8')
+
+        when:
+        new FileParser().parseFile(invalidTempFile)
+
+        then:
+        thrown(ExciteException)
+    }
+
+    def cleanup() {
+        validTempFile?.delete()
+        invalidTempFile?.delete()
+    }
+
+}

--- a/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/parser/FilePredicateTest.groovy
+++ b/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/parser/FilePredicateTest.groovy
@@ -1,0 +1,19 @@
+package com.parisesoftware.excite.core.internal.parser
+
+import spock.lang.Specification
+
+class FilePredicateTest extends Specification {
+
+    def "isXmlFile returns expected result for various file names"(File file, boolean expected) {
+        expect:
+        FilePredicate.isXmlFile.test(file) == expected
+
+        where:
+        file                    || expected
+        new File('test.xml')    || true
+        new File('TEST.XML')    || true
+        new File('test.txt')    || false
+        new File('noext')       || false
+    }
+
+}

--- a/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/parser/FileSystemServiceTest.groovy
+++ b/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/parser/FileSystemServiceTest.groovy
@@ -1,0 +1,37 @@
+package com.parisesoftware.excite.core.internal.parser
+
+import com.parisesoftware.excite.core.api.ExciteException
+import spock.lang.Specification
+
+class FileSystemServiceTest extends Specification {
+
+    File tempDir
+
+    def "getFilesInDirectory returns only XML files from a directory"() {
+        given:
+        tempDir = File.createTempDir()
+        new File(tempDir, 'file1.xml').setText('<root/>', 'UTF-8')
+        new File(tempDir, 'file2.xml').setText('<root/>', 'UTF-8')
+        new File(tempDir, 'file3.txt').setText('plain text', 'UTF-8')
+
+        when:
+        List<File> result = new FileSystemService().getFilesInDirectory(tempDir.absolutePath)
+
+        then:
+        result.size() == 2
+        result.every { it.name.endsWith('.xml') }
+    }
+
+    def "getFilesInDirectory throws ExciteException for non-existent path"() {
+        when:
+        new FileSystemService().getFilesInDirectory('/this/path/does/not/exist/at/all')
+
+        then:
+        thrown(ExciteException)
+    }
+
+    def cleanup() {
+        tempDir?.deleteDir()
+    }
+
+}

--- a/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/transformer/DeleteChildNodeByNameTransformationTest.groovy
+++ b/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/transformer/DeleteChildNodeByNameTransformationTest.groovy
@@ -1,0 +1,23 @@
+package com.parisesoftware.excite.core.internal.transformer
+
+import groovy.xml.XmlSlurper
+import groovy.xml.XmlUtil
+import groovy.xml.slurpersupport.GPathResult
+import spock.lang.Specification
+
+class DeleteChildNodeByNameTransformationTest extends Specification {
+
+    def "execute removes the target child node"() {
+        given:
+        GPathResult root = new XmlSlurper().parseText('<root><target>value</target><other>keep</other></root>')
+
+        when:
+        new DeleteChildNodeByNameTransformation('target').execute(root)
+        String result = XmlUtil.serialize(root)
+
+        then:
+        !result.contains('<target>')
+        result.contains('keep')
+    }
+
+}

--- a/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/transformer/MarkupTransformerTest.groovy
+++ b/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/transformer/MarkupTransformerTest.groovy
@@ -1,0 +1,22 @@
+package com.parisesoftware.excite.core.internal.transformer
+
+import com.parisesoftware.excite.core.api.ITransformationAlgorithm
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.GPathResult
+import spock.lang.Specification
+
+class MarkupTransformerTest extends Specification {
+
+    def "transform with no-op algorithm returns serialized XML starting with XML declaration"() {
+        given:
+        GPathResult root = new XmlSlurper().parseText('<root><child>text</child></root>')
+        ITransformationAlgorithm noOp = { GPathResult node -> } as ITransformationAlgorithm
+
+        when:
+        String result = new MarkupTransformer().transform(root, noOp)
+
+        then:
+        result.startsWith('<?xml')
+    }
+
+}

--- a/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/transformer/RenameChildNodeTransformationTest.groovy
+++ b/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/transformer/RenameChildNodeTransformationTest.groovy
@@ -1,0 +1,24 @@
+package com.parisesoftware.excite.core.internal.transformer
+
+import groovy.xml.XmlSlurper
+import groovy.xml.XmlUtil
+import groovy.xml.slurpersupport.GPathResult
+import spock.lang.Specification
+
+class RenameChildNodeTransformationTest extends Specification {
+
+    def "execute renames old node to new node and preserves value"() {
+        given:
+        GPathResult root = new XmlSlurper().parseText('<root><old>value</old></root>')
+
+        when:
+        new RenameChildNodeTransformation('old', 'newname').execute(root)
+        String result = XmlUtil.serialize(root)
+
+        then:
+        result.contains('newname')
+        result.contains('value')
+        !result.contains('<old>')
+    }
+
+}

--- a/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/transformer/operation/GPathResultTransformerTest.groovy
+++ b/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/transformer/operation/GPathResultTransformerTest.groovy
@@ -1,0 +1,46 @@
+package com.parisesoftware.excite.core.internal.transformer.operation
+
+import groovy.xml.XmlSlurper
+import groovy.xml.XmlUtil
+import groovy.xml.slurpersupport.GPathResult
+import spock.lang.Specification
+
+class GPathResultTransformerTest extends Specification {
+
+    def "deleteChildNodesWithName removes the specified child node"() {
+        given:
+        GPathResult root = new XmlSlurper().parseText('<root><child>val</child></root>')
+
+        when:
+        GPathResultTransformer.deleteChildNodesWithName(root, 'child')
+        String result = XmlUtil.serialize(root)
+
+        then:
+        !result.contains('<child>')
+    }
+
+    def "renameChildNodesWithName renames the specified child node and preserves its value"() {
+        given:
+        GPathResult root = new XmlSlurper().parseText('<root><child>val</child></root>')
+
+        when:
+        GPathResultTransformer.renameChildNodesWithName(root, 'child', 'renamed')
+        String result = XmlUtil.serialize(root)
+
+        then:
+        result.contains('renamed')
+        result.contains('val')
+    }
+
+    def "deleteChildNodesWithName does not throw when name does not exist"() {
+        given:
+        GPathResult root = new XmlSlurper().parseText('<root><child>val</child></root>')
+
+        when:
+        GPathResultTransformer.deleteChildNodesWithName(root, 'nonexistent')
+
+        then:
+        noExceptionThrown()
+    }
+
+}

--- a/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/validation/AcceptAllValidationTest.groovy
+++ b/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/validation/AcceptAllValidationTest.groovy
@@ -1,5 +1,6 @@
 package com.parisesoftware.excite.core.internal.validation
 
+import groovy.xml.XmlSlurper
 import groovy.xml.slurpersupport.GPathResult
 import spock.lang.Specification
 
@@ -10,8 +11,9 @@ class AcceptAllValidationTest extends Specification {
         new AcceptAllValidation().validate(aNode) == isValid
 
         where:
-        aNode               || isValid
-        null                || false
+        aNode                                             || isValid
+        null                                              || false
+        new XmlSlurper().parseText('<root/>')             || true
     }
 
 }

--- a/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/validation/ChildNodeHasValueValidationTest.groovy
+++ b/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/validation/ChildNodeHasValueValidationTest.groovy
@@ -1,0 +1,38 @@
+package com.parisesoftware.excite.core.internal.validation
+
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.GPathResult
+import spock.lang.Specification
+
+class ChildNodeHasValueValidationTest extends Specification {
+
+    def "validate returns false for null node"() {
+        expect:
+        new ChildNodeHasValueValidation('type', 'match').validate(null) == false
+    }
+
+    def "validate returns false when target child node is absent"() {
+        given:
+        GPathResult node = new XmlSlurper().parseText('<root/>')
+
+        expect:
+        new ChildNodeHasValueValidation('type', 'match').validate(node) == false
+    }
+
+    def "validate returns false when child node has wrong value"() {
+        given:
+        GPathResult node = new XmlSlurper().parseText('<root><type>wrong</type></root>')
+
+        expect:
+        new ChildNodeHasValueValidation('type', 'match').validate(node) == false
+    }
+
+    def "validate returns true when child node has correct value"() {
+        given:
+        GPathResult node = new XmlSlurper().parseText('<root><type>match</type></root>')
+
+        expect:
+        new ChildNodeHasValueValidation('type', 'match').validate(node) == true
+    }
+
+}

--- a/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/validation/ValidationMethodTest.groovy
+++ b/excite-core/src/test/groovy/com/parisesoftware/excite/core/internal/validation/ValidationMethodTest.groovy
@@ -1,0 +1,22 @@
+package com.parisesoftware.excite.core.internal.validation
+
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.GPathResult
+import spock.lang.Specification
+
+class ValidationMethodTest extends Specification {
+
+    def "ACCEPT_ALL predicate returns false for null"() {
+        expect:
+        ValidationMethod.ACCEPT_ALL.test(null) == false
+    }
+
+    def "ACCEPT_ALL predicate returns true for a valid GPathResult"() {
+        given:
+        GPathResult node = new XmlSlurper().parseText('<root/>')
+
+        expect:
+        ValidationMethod.ACCEPT_ALL.test(node) == true
+    }
+
+}


### PR DESCRIPTION
Adds 13 Spock specification files covering AcceptAllValidation, ChildNodeHasValueValidation, ValidationMethod, FilePredicate, FileParser, FileSystemService, GPathResultTransformer, RenameChildNodeTransformation, DeleteChildNodeByNameTransformation, MarkupTransformer, OverwriteFileOutputCommand, ConsoleOutputCommand, and an end-to-end integration test.