### PR TITLE
[Wave 3-H] Performance

### DIFF
--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/api/resolver/IFileSystemService.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/api/resolver/IFileSystemService.groovy
@@ -1,6 +1,8 @@
 package com.parisesoftware.excite.core.api.resolver
 
+import java.io.IOException
 import java.util.function.Predicate
+import java.util.stream.Stream
 
 /**
  * File System Service Abstraction
@@ -24,6 +26,17 @@ interface IFileSystemService {
 
     default List<File> getFilesInDirectory(final String aFilePath) {
         return getFilesInDirectory(aFilePath, com.parisesoftware.excite.core.internal.parser.FilePredicate.isXmlFile)
+    }
+
+    default Stream<File> streamFilesInDirectory(final String aFilePath, final Predicate<File> isApplicableFile) {
+        try {
+            return java.nio.file.Files.walk(java.nio.file.Paths.get(aFilePath))
+                .filter { java.nio.file.Path p -> java.nio.file.Files.isRegularFile(p) }
+                .map { java.nio.file.Path p -> p.toFile() }
+                .filter { File f -> isApplicableFile.test(f) }
+        } catch (IOException e) {
+            throw new com.parisesoftware.excite.core.api.ExciteException("Failed to stream directory: ${aFilePath}", e)
+        }
     }
 
 }

--- a/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/ExciteFacadeImpl.groovy
+++ b/excite-core/src/main/groovy/com/parisesoftware/excite/core/internal/ExciteFacadeImpl.groovy
@@ -53,6 +53,10 @@ class ExciteFacadeImpl implements IExciteFacade {
 
     /**
      * {@inheritDoc}
+     *
+     * <p>
+     * Files are processed concurrently via a parallel stream. Custom {@link IOutputCommand}
+     * implementations must be thread-safe.
      */
     void run(final String aDirectory,
              final ITransformationAlgorithm aTransformationAlgorithm,
@@ -64,8 +68,7 @@ class ExciteFacadeImpl implements IExciteFacade {
         if (anOutputCommand == null) throw new IllegalArgumentException('anOutputCommand must not be null')
         log.debug('Running Excite against directory: {}', aDirectory)
         List<File> filesInDirectory = this.fileSystemService.getFilesInDirectory(aDirectory, GET_ONLY_XML_FILES)
-        filesInDirectory.each { File curFile ->
-            log.info('Processing: {}', curFile.name)
+        filesInDirectory.parallelStream().forEach { File curFile ->
             try {
                 GPathResult fileContents = this.fileParser.parseFile(curFile)
                 if (aValidationAlgorithm.validate(fileContents)) {
@@ -73,6 +76,7 @@ class ExciteFacadeImpl implements IExciteFacade {
                     anOutputCommand.execute(curFile, transformedContent)
                 }
             } catch (ExciteException e) {
+                log.error('Failed to process file: {}', curFile.absolutePath, e)
                 throw e
             } catch (Exception e) {
                 log.error('Failed to process file: {}', curFile.absolutePath, e)


### PR DESCRIPTION
Adds Stream<File>-based directory scanning via IFileSystemService.streamFilesInDirectory(). Switches ExciteFacadeImpl pipeline loop to parallelStream() for concurrent file processing. Custom IOutputCommand implementations must be thread-safe.